### PR TITLE
add --input-dice-results option

### DIFF
--- a/tests/exp_help_output.txt
+++ b/tests/exp_help_output.txt
@@ -1,4 +1,4 @@
-usage: diceware [-h] [-n NUM] [-c | --no-caps] [-s NUM] [-d DELIMITER]
+usage: diceware [-h] [-n NUM] [-c | --no-caps] [-s NUM] [-d DELIMITER] [-i]
                 [--version]
                 [INFILE]
 
@@ -16,4 +16,7 @@ optional arguments:
                         Insert NUM special chars into generated word.
   -d DELIMITER, --delimiter DELIMITER
                         Separate words by DELIMITER. Empty string by default.
+  -i, --input-dice-results
+                        Input dice results instead of choosing randomly
+                        (ignore "-n").
   --version             output version information and exit.


### PR DESCRIPTION
Add the possibility of inputting the result of real dice throws instead of using the computer's PRNG. This is useful so you can use diceware as a word catalog, while also using other features of the program.