### PR TITLE
Fix real dice input range validation

### DIFF
--- a/diceware/random_sources.py
+++ b/diceware/random_sources.py
@@ -151,7 +151,7 @@ class RealDiceRandomSource(object):
         result = 0
         for i in range(num_rolls, 0, -1):
             rolled = None
-            while rolled not in [str(x) for x in range(self.dice_sides)]:
+            while rolled not in [str(x) for x in range(1, self.dice_sides + 1)]:
                 rolled = input_func(
                     "What number shows dice number %s? " % (num_rolls - i + 1))
             result += ((self.dice_sides ** (i - 1)) * (int(rolled) - 1))


### PR DESCRIPTION
The current implementation of real dice input will accept values from 0 to the number of sides of the dice minus one. I think it makes more sense to instead accept exactly what the result of the dice says, i.e. from 1 to the number of sides.

This change also fixes the mapping to the wordlist, because a result of 11111 will correctly map to the first entry of the wordlist, and a result of 66666 will correctly map to the 7776th elemtn of the list, as originally proposed in diceware.com.