### PR TITLE
Change capitalize to caps

### DIFF
--- a/diceware/__init__.py
+++ b/diceware/__init__.py
@@ -95,7 +95,7 @@ def handle_options(args):
         '-c', '--caps', action='store_true',
         help='Capitalize words. This is the default.')
     cap_group.add_argument(
-        '--no-caps', action='store_false', dest='capitalize',
+        '--no-caps', action='store_false', dest='caps',
         help='Turn off capitalization.')
     parser.add_argument(
         '-s', '--specials', default=0, type=int, metavar='NUM',
@@ -158,7 +158,7 @@ def get_passphrase(options=None):
     registered under the name `options.randomsource` (something like
     "system" or "dice").
 
-    If `options.capitalize` is ``True``, all words will be capitalized.
+    If `options.caps` is ``True``, all words will be caps.
 
     If `options.infile`, a file descriptor, is given, it will be used
     instead of a 'built-in' wordlist. `options.infile` must be open for
@@ -172,7 +172,7 @@ def get_passphrase(options=None):
     rnd_source = get_random_sources()[options.randomsource]
     rnd = rnd_source(options)
     words = [rnd.choice(list(word_list)) for x in range(options.num)]
-    if options.capitalize:
+    if options.caps:
         words = [x.capitalize() for x in words]
     result = options.delimiter.join(words)
     for _ in range(options.specials):

--- a/tests/test_diceware.py
+++ b/tests/test_diceware.py
@@ -77,7 +77,7 @@ class TestDicewareModule(object):
     def test_get_passphrase_no_capitals(self):
         # we can turn capitals off
         options = handle_options(args=[])
-        options.capitalize = False
+        options.caps = False
         phrase = get_passphrase(options)
         assert phrase.lower() == phrase
 
@@ -129,7 +129,7 @@ class TestDicewareModule(object):
         # defaults are correctly set
         options = handle_options([])
         assert options.num == 6
-        assert options.capitalize is True
+        assert options.caps is True
         assert options.specials == 0
         assert options.infile is None
         assert options.version is False
@@ -194,7 +194,7 @@ class TestDicewareModule(object):
         assert out == ''
         assert "invalid choice" in err
 
-    def test_handle_options_considers_configfile(self, home_dir):
+    def test_handle_options_considers_configfile(self, home_dir, capsys):
         # defaults from a local configfile are respected
         config_file = home_dir / ".diceware.ini"
         config_file.write("\n".join(
@@ -207,6 +207,13 @@ class TestDicewareModule(object):
         assert options.num == 3
         assert options.delimiter == "my-delim"
         assert options.caps is False
+        # Now test the main program
+        sys.stdin = StringIO("word1\n")
+        sys.argv = ['diceware', '-']
+        main()  # call with default options in place
+        out, err = capsys.readouterr()
+        assert out == 'word1my-delimword1my-delimword1\n'
+
 
     def test_main(self, capsys):
         # we can get a passphrase


### PR DESCRIPTION
This commit fixes issue #21.
Change all occurences of the option `capitalize` to `caps` in
__init.py__.

Make the same change in the test_diceware.py.
Add a unit test that checks the output of main() after setting the
`caps = off` in the .diceware.ini.