### PR TITLE
Fix issue 23

### DIFF
--- a/diceware/config.py
+++ b/diceware/config.py
@@ -82,5 +82,5 @@ def get_config_dict(path_list=None):
         elif isinstance(val, int):
             result[key] = parser.getint("diceware", key)
         else:
-            result[key] = parser.get("diceware", key)
+            result[key] = parser.get("diceware", key).strip("\"'")
     return result

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -101,6 +101,22 @@ class TestConfigModule(object):
         conf_dict = get_config_dict()
         assert conf_dict["delimiter"] == ""
 
+    def test_get_config_dict_string_space(self, home_dir):
+        # We test for the following three cases of whitespace delimiter
+        # delimiter=" "
+        # delimiter=' '
+        # delimiter="  " (two spaces)
+        config_file = home_dir / ".diceware.ini"
+        config_file.write("\n".join(["[diceware]", "delimiter=\" \""]))
+        conf_dict = get_config_dict()
+        assert conf_dict["delimiter"] == " "
+        config_file.write("\n".join(["[diceware]", "delimiter=' '"]))
+        conf_dict = get_config_dict()
+        assert conf_dict["delimiter"] == " "
+        config_file.write("\n".join(["[diceware]", "delimiter=\"  \""]))
+        conf_dict = get_config_dict()
+        assert conf_dict["delimiter"] == "  "
+
 
 class TestSampleIni(object):
     # test local sample ini file


### PR DESCRIPTION
This commit fixes #23

Add the `string.strip()` function to the `get_config_dict()`, to remove
inverted commas around string values in the diceware.ini file.
The strip removes both `"` and `'`.
Add unit test to ensure the line:

    delimiter=" "

in the diceware.ini file is being parsed correctly as a space.