### PR TITLE
Feature realdice command argument

### DIFF
--- a/diceware/__init__.py
+++ b/diceware/__init__.py
@@ -110,6 +110,12 @@ def handle_options(args):
             "Get randomness from this source. Possible values: `%s'. "
             "Default: system" % "', `".join(sorted(random_sources))))
     parser.add_argument(
+        '--dice-rolls', default=None, type=int, nargs="+",
+        metavar="NUM" , dest="dice_rolls_list",
+        help=("Provide a sequence of dice rolls from a six sided die, "
+              "separated by spaces. "
+              "Example of possible input: 1 2 3 4 5 6 6."))
+    parser.add_argument(
         '-w', '--wordlist', default='en_securedrop', choices=wordlist_names,
         metavar="NAME",
         help=(

--- a/diceware/__init__.py
+++ b/diceware/__init__.py
@@ -175,6 +175,10 @@ def get_passphrase(options=None):
     if options.infile is None:
         options.infile = open(get_wordlist_path(options.wordlist), 'r')
     word_list = WordList(options.infile)
+    if options.dice_rolls_list is not None:
+        if options.randomsource is not 'realdice':
+            print('Warning: Using realdice as random source, with given dice rolls')
+        options.randomsource = 'realdice'
     rnd_source = get_random_sources()[options.randomsource]
     rnd = rnd_source(options)
     words = [rnd.choice(list(word_list)) for x in range(options.num)]

--- a/diceware/random_sources.py
+++ b/diceware/random_sources.py
@@ -124,6 +124,16 @@ class RealDiceRandomSource(object):
     def __init__(self, options):
         self.options = options
         self.dice_sides = 6
+        self.dice_rolls_list = None
+        # Some tests don't pass any options.
+        # Here we ensure that dice_rolls_list created nonetheless.
+        if hasattr(self.options, "dice_rolls_list"):
+            self.dice_rolls_list = self.options.dice_rolls_list
+        if self.dice_rolls_list is not None:
+            self.dice_rolls_list = [x for x in self.dice_rolls_list if x <= self.dice_sides]
+        #TODO Put the expected_output back in the unit-test
+        #TODO Make the --dice-rolls option automatically set the source to `realdice`
+
 
     def pre_check(self, num_rolls, sequence):
         """Checks performed before picking an item of a sequence.
@@ -163,11 +173,17 @@ class RealDiceRandomSource(object):
         self.pre_check(num_rolls, sequence)
         result = 0
         for i in range(num_rolls, 0, -1):
-            rolled = None
-            while rolled not in [
-                    str(x) for x in range(1, self.dice_sides + 1)]:
-                rolled = input_func(
-                    "What number shows dice number %s? " % (num_rolls - i + 1))
+            if self.dice_rolls_list is not None and len(self.dice_rolls_list) is not 0:
+                rolled = self.dice_rolls_list.pop()
+                print("Roll %s given as %s" % (num_rolls - i + 1 , rolled))
+                if len(self.dice_rolls_list) is 0 and i > 1:
+                    print("Not enough rolls given, please roll a real dice")
+            else: # this means there is no more dice rolls left in the given list
+                rolled = None
+                while rolled not in [
+                        str(x) for x in range(1, self.dice_sides + 1)]:
+                    rolled = input_func(
+                        "What number shows dice number %s? " % (num_rolls - i + 1))
             result += ((self.dice_sides ** (i - 1)) * (int(rolled) - 1))
             result = result % len(sequence)
         return sequence[result]

--- a/diceware/random_sources.py
+++ b/diceware/random_sources.py
@@ -132,7 +132,6 @@ class RealDiceRandomSource(object):
         if self.dice_rolls_list is not None:
             self.dice_rolls_list = [x for x in self.dice_rolls_list if x <= self.dice_sides]
         #TODO Put the expected_output back in the unit-test
-        #TODO Make the --dice-rolls option automatically set the source to `realdice`
 
 
     def pre_check(self, num_rolls, sequence):

--- a/diceware/random_sources.py
+++ b/diceware/random_sources.py
@@ -131,7 +131,6 @@ class RealDiceRandomSource(object):
             self.dice_rolls_list = self.options.dice_rolls_list
         if self.dice_rolls_list is not None:
             self.dice_rolls_list = [x for x in self.dice_rolls_list if x <= self.dice_sides]
-        #TODO Put the expected_output back in the unit-test
 
 
     def pre_check(self, num_rolls, sequence):

--- a/tests/exp_help_output.txt
+++ b/tests/exp_help_output.txt
@@ -1,5 +1,5 @@
 usage: diceware [-h] [-n NUM] [-c | --no-caps] [-s NUM] [-d DELIMITER]
-                [-r SOURCE] [-w NAME] [--version]
+                [-r SOURCE] [--dice-rolls NUM [NUM ...]] [-w NAME] [--version]
                 [INFILE]
 
 Create a passphrase
@@ -19,6 +19,10 @@ optional arguments:
   -r SOURCE, --randomsource SOURCE
                         Get randomness from this source. Possible values:
                         `realdice', `system'. Default: system
+  --dice-rolls NUM [NUM ...]
+                        Provide a sequence of dice rolls from a six sided die,
+                        separated by spaces. Example of possible input: 1 2 3
+                        4 5 6 6.
   -w NAME, --wordlist NAME
                         Use words from this wordlist. Possible values: `en',
                         `en_orig', `en_securedrop'. Wordlists are stored in

--- a/tests/test_diceware.py
+++ b/tests/test_diceware.py
@@ -133,6 +133,17 @@ class TestHandleOptions(object):
         assert options.delimiter == "my-delim"
         assert options.caps is False
 
+    def test_handle_options_get_dice_rolls(self):
+        options = handle_options(args=["--dice-rolls", "1", "2", "3"])
+        assert [1,2,3] == options.dice_rolls_list
+        # Should give error if no arguments
+        with pytest.raises(SystemExit):
+            handle_options(args=["--dice-rolls"])
+        # Value should be None if option not given
+        options = handle_options(args=[])
+        assert options.dice_rolls_list is None
+
+
 
 class TestDicewareModule(object):
 
@@ -252,7 +263,7 @@ class TestDicewareModule(object):
             expected_output = fd.read()
         out = out.replace(WORDLISTS_DIR, "<WORDLISTS-DIR>")
         out = out.replace("\n<WORDLISTS-DIR>", " <WORDLISTS-DIR>")
-        assert out == expected_output
+        # assert out == expected_output
 
     def test_main_version(self, argv_handler, capsys):
         # we can get version infos.

--- a/tests/test_diceware.py
+++ b/tests/test_diceware.py
@@ -272,7 +272,7 @@ class TestDicewareModule(object):
             expected_output = fd.read()
         out = out.replace(WORDLISTS_DIR, "<WORDLISTS-DIR>")
         out = out.replace("\n<WORDLISTS-DIR>", " <WORDLISTS-DIR>")
-        # assert out == expected_output
+        assert out == expected_output
 
     def test_main_version(self, argv_handler, capsys):
         # we can get version infos.

--- a/tests/test_diceware.py
+++ b/tests/test_diceware.py
@@ -226,6 +226,15 @@ class TestDicewareModule(object):
         phrase = get_passphrase(options)
         assert "Word1" in phrase
 
+    def test_get_passphrase_realdice(self, capsys):
+        # Test whether the option "--dice-rolls" forces the randomsource option to be realdice
+        sys.stdin = StringIO("word1\n")
+        options = handle_options(args=["--dice-rolls", "1", "1","-n", "1", "-"])
+        phrase = get_passphrase(options)
+        out, err = capsys.readouterr()
+        assert options.randomsource == "realdice"
+        assert "Using realdice as random source, with given dice rolls" in out
+
     def test_print_version(self, capsys):
         # we can print version infos
         print_version()


### PR DESCRIPTION
This feature doesn't add any vital functionality. It adds a command argument `--dice-rolls`, to be used as follows:

```bash
diceware -n 1 --dice-rolls 1 2 4 5 3 2 1
```
The rolls is stored in a list, which are used before the user is prompted to roll a dice. When I use diceware, I usually roll a box full of dice and I read off the values from left to right. This makes it easier for me to input all the values at once in the initial command.

Also added unit tests for all the functionality, and updated the `expected_output` of the `--help` unit test.

*Now, there is one big  security caveat to this method:* the bash commands are stored in your bash history, so the rolls that generated your password is shown in plaintext there. I only realised this late in the process, and I would understand if the merge was rejected just on the basis of this flaw.

A possible way to fix this, while keeping the functionality, is to add an argument like `--oneline` that would prompt the user to input a series of dice rolls in one long line, rather than asking the user roll-by-roll. The rolls wouldn't be in the bash history then. I would be happy to change my code to reflect such a request.

As I said, I only noticed this security issue after completing the request. I learned a lot from adding this feature, and I still use it to play around and experiment myself. Thus, I would not be piqued if the feature wasn't accepted, but I thought I would submit the request rather than disqualify it myself, just in case you see  a benefit to it.