### PR TITLE
Small fix for RealDiceRandomSource

### DIFF
--- a/diceware/random_sources.py
+++ b/diceware/random_sources.py
@@ -131,7 +131,7 @@ class RealDiceRandomSource(object):
         self.options = options
         self.dice_sides = 6
         if options is not None:
-            self.dice_sides = options.get('dice_sides', 6)
+            self.dice_sides = getattr(options, 'dice_sides', 6)
 
     def pre_check(self, num_rolls, sequence):
         """Checks performed before picking an item of a sequence.

--- a/tests/test_random_sources.py
+++ b/tests/test_random_sources.py
@@ -1,6 +1,8 @@
 import pkg_resources
 import pytest
 
+import argparse
+
 from diceware.random_sources import (
     SystemRandomSource, RealDiceRandomSource,
     )
@@ -125,7 +127,7 @@ class TestRealDiceRandomSource(object):
 
     def test_options_are_stored(self):
         # options passed-in are stored with RealDiceRandomSource instances
-        options = dict(fake=1)
+        options = "fake_check"
         src = RealDiceRandomSource(options)
         assert src.options is options
 
@@ -286,7 +288,9 @@ class TestRealDiceRandomSource(object):
     def test_dice_sides_respected(self, capsys, monkeypatch):
         # we use the number of dice sides given by options dict.
         self.fake_input_values(["1", "2"], monkeypatch)
-        src = RealDiceRandomSource(dict(dice_sides=2))  # a coin
+        # A Namespace, not a dict, is passed to the constructor.
+        options = argparse.Namespace(dice_sides=2)  # a coin
+        src = RealDiceRandomSource(options)
         picked = src.choice(['a', 'b', 'c', 'd'])
         out, err = capsys.readouterr()
         # must throw a coin 2 times to pick one out of 4 items


### PR DESCRIPTION
In Python 2.7 and 3.5 on Windows 10, using the 'realdice' randomness source fails "out of the box" because the constructor for RealDiceRandomSource unsuccessfully attempts to access an argparse.Namespace object as a dict. This change fixes that issue and updates a test for the constructor.
