### PR TITLE
use function to get wordlists dir

### DIFF
--- a/diceware/__init__.py
+++ b/diceware/__init__.py
@@ -22,7 +22,7 @@ from random import SystemRandom
 from diceware.config import get_config_dict
 from diceware.logger import configure
 from diceware.wordlist import (
-    WordList, get_wordlist_path, WORDLISTS_DIR, get_wordlist_names,
+    WordList, get_wordlist_path, get_wordlists_dir, get_wordlist_names,
     )
 
 __version__ = pkg_resources.get_distribution('diceware').version
@@ -86,7 +86,7 @@ def handle_options(args):
     defaults = get_config_dict()
     parser = argparse.ArgumentParser(
         description="Create a passphrase",
-        epilog="Wordlists are stored in %s" % WORDLISTS_DIR
+        epilog="Wordlists are stored in %s" % get_wordlists_dir()
         )
     parser.add_argument(
         '-n', '--num', default=6, type=int,

--- a/diceware/wordlist.py
+++ b/diceware/wordlist.py
@@ -27,9 +27,14 @@ import tempfile
 #: disk.
 MAX_IN_MEM_SIZE = 20 * 1024 * 1024
 
+
 #: The directory in which wordlists are stored
-WORDLISTS_DIR = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), 'wordlists'))
+def get_wordlists_dir():
+    """Get the directory for local storage of wordlists.
+    """
+    return os.path.abspath(
+        os.path.join(os.path.dirname(__file__), 'wordlists'))
+
 
 #: A regular expression matching allowed wordlist names. We
 #: allow names that cannot easily mess up filesystems.
@@ -47,9 +52,10 @@ def get_wordlist_names():
     """Get a all names of wordlists stored locally.
     """
     result = []
-    filenames = os.listdir(WORDLISTS_DIR)
+    wordlists_dir = get_wordlists_dir()
+    filenames = os.listdir(wordlists_dir)
     for filename in filenames:
-        if not os.path.isfile(os.path.join(WORDLISTS_DIR, filename)):
+        if not os.path.isfile(os.path.join(wordlists_dir, filename)):
             continue
         match = RE_VALID_WORDLIST_FILENAME.match(filename)
         if not match:
@@ -70,12 +76,13 @@ def get_wordlist_path(name):
     """
     if not RE_WORDLIST_NAME.match(name):
         raise ValueError("Not a valid wordlist name: %s" % name)
-    for filename in os.listdir(WORDLISTS_DIR):
-        if not os.path.isfile(os.path.join(WORDLISTS_DIR, filename)):
+    wordlists_dir = get_wordlists_dir()
+    for filename in os.listdir(wordlists_dir):
+        if not os.path.isfile(os.path.join(wordlists_dir, filename)):
             continue
         match = RE_VALID_WORDLIST_FILENAME.match(filename)
         if match and match.groups()[0] == name:
-            return os.path.join(WORDLISTS_DIR, filename)
+            return os.path.join(wordlists_dir, filename)
 
 
 class WordList(object):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,7 @@ def argv_handler(request):
 def wordlists_dir(request, monkeypatch, tmpdir):
     """This fixture provides a temporary wordlist dir.
     """
-    monkeypatch.setattr("diceware.wordlist.WORDLISTS_DIR", str(tmpdir))
+    monkeypatch.setattr("diceware.wordlist.get_wordlists_dir", lambda: str(tmpdir))
     return tmpdir
 
 

--- a/tests/test_diceware.py
+++ b/tests/test_diceware.py
@@ -6,7 +6,7 @@ import re
 import sys
 from io import StringIO
 from diceware import (
-    WORDLISTS_DIR, SPECIAL_CHARS, insert_special_char, get_passphrase,
+    get_wordlists_dir, SPECIAL_CHARS, insert_special_char, get_passphrase,
     handle_options, main, __version__, print_version, get_random_sources,
     get_wordlist_names
     )
@@ -278,7 +278,8 @@ class TestDicewareModule(object):
             os.path.dirname(__file__), 'exp_help_output.txt')
         with open(expected_path, 'r') as fd:
             expected_output = fd.read()
-        out = out.replace(WORDLISTS_DIR, "<WORDLISTS-DIR>")
+        wordlists_dir = get_wordlists_dir()
+        out = out.replace(wordlists_dir, "<WORDLISTS-DIR>")
         out = out.replace("\n<WORDLISTS-DIR>", " <WORDLISTS-DIR>")
         assert out == expected_output
 

--- a/tests/test_wordlist.py
+++ b/tests/test_wordlist.py
@@ -3,7 +3,7 @@ import pytest
 import sys
 from io import StringIO
 from diceware.wordlist import (
-    WORDLISTS_DIR, RE_WORDLIST_NAME, RE_NUMBERED_WORDLIST_ENTRY,
+    get_wordlists_dir, RE_WORDLIST_NAME, RE_NUMBERED_WORDLIST_ENTRY,
     RE_VALID_WORDLIST_FILENAME, get_wordlist_path, get_wordlist_names,
     WordList,
 )
@@ -207,7 +207,8 @@ class TestWordList(object):
 
     def test_wordlist_en_8k(self):
         # we can get a list of words out of the reinhold english 8k wordlist.
-        en_src = os.path.join(WORDLISTS_DIR, 'wordlist_en.txt')
+        wordlists_dir = get_wordlists_dir()
+        en_src = os.path.join(wordlists_dir, 'wordlist_en.txt')
         w_list = WordList(en_src)
         long_list = list(w_list)
         assert long_list[0] == "a"
@@ -216,7 +217,8 @@ class TestWordList(object):
 
     def test_wordlist_en_securedrop(self):
         # we can get a list of words out of securedrop english 8k wordlist.
-        en_src = os.path.join(WORDLISTS_DIR, 'wordlist_en_securedrop.asc')
+        wordlists_dir = get_wordlists_dir()
+        en_src = os.path.join(wordlists_dir, 'wordlist_en_securedrop.asc')
         w_list = WordList(en_src)
         long_list = list(w_list)
         assert long_list[0] == "0"
@@ -225,7 +227,8 @@ class TestWordList(object):
 
     def test_wordlist_en(self):
         # we can get a list of words out of the original diceware wordlist.
-        en_src = os.path.join(WORDLISTS_DIR, 'wordlist_en_orig.asc')
+        wordlists_dir = get_wordlists_dir()
+        en_src = os.path.join(wordlists_dir, 'wordlist_en_orig.asc')
         w_list = list(WordList(en_src))
         assert w_list[0] == "a"
         assert w_list[-1] == "@"
@@ -233,7 +236,8 @@ class TestWordList(object):
 
     def test_wordlist_en_eff(self):
         # we can get a list of words out of the EFF-maintained wordlist.
-        en_src = os.path.join(WORDLISTS_DIR, 'wordlist_en_eff.txt')
+        wordlists_dir = get_wordlists_dir()
+        en_src = os.path.join(wordlists_dir, 'wordlist_en_eff.txt')
         w_list = list(WordList(en_src))
         assert w_list[0] == "abacus"
         assert w_list[-1] == "zoom"
@@ -272,7 +276,8 @@ class TestWordList(object):
 
     def test_get_signed_wordlist_handles_en_orig(self):
         # we can process the original diceware list from diceware.com
-        wlist_path = os.path.join(WORDLISTS_DIR, 'wordlist_en_orig.asc')
+        wordlists_dir = get_wordlists_dir()
+        wlist_path = os.path.join(wordlists_dir, 'wordlist_en_orig.asc')
         w_list = WordList(wlist_path)
         result = list(w_list)
         assert len(result) == 7776


### PR DESCRIPTION
The path to wordlist files is hardcoded in the generated sphinx
documentation and because it may differ depending on how the package is
installed this creates different problems:

  - the path hardcoded in the online api documentation may differ from
    the one in each installation, leading to incorrect information
    provided to the user of the api.

  - packaging diceware documentation to specific operating systems may
    generate unreproducible packages.

This commit replaces the variable WORDLISTS_DIR by a function called
get_wordlists_dir() that delays the construction of the path instead of
doing it during module loading.