### PR TITLE
no more warning on entropy and no repeat

### DIFF
--- a/diceware/random_sources.py
+++ b/diceware/random_sources.py
@@ -156,7 +156,7 @@ class RealDiceRandomSource(object):
     def get_num_rolls(self, seq_len):
         """Compute how many dice rolls we need to pick a value from a sequence
         """
-        num_rolls = int(math.log(seq_len, self.dice_sides))
+        num_rolls = math.ceil(math.log(seq_len, self.dice_sides))
         if num_rolls < 1:
             # If this happens, there are less values in the sequence to
             # choose from than there are dice sides.
@@ -169,20 +169,16 @@ class RealDiceRandomSource(object):
         if len(sequence) == 1:
             return sequence[0]  # no need to roll dice.
         num_rolls = self.get_num_rolls(len(sequence))
+        max_result = self.dice_sides ** num_rolls
         self.pre_check(num_rolls, sequence)
-        repeat = True
-        while repeat:
-            result = 0
-            for i in range(num_rolls, 0, -1):
-                rolled = None
-                while rolled not in [
-                        str(x) for x in range(1, self.dice_sides + 1)]:
-                    rolled = input_func(
-                        "What number shows dice number %s? " % (
-                            num_rolls - i + 1))
-                result += ((self.dice_sides ** (i - 1)) * (int(rolled) - 1))
-            if result < len(sequence):
-                repeat = False
-            else:
-                print("Value out of range. Please roll dice again.")
-        return sequence[result]
+        result = 0
+        for i in range(num_rolls, 0, -1):
+            rolled = None
+            while rolled not in [
+                    str(x) for x in range(1, self.dice_sides + 1)]:
+                rolled = input_func(
+                    "What number shows dice number %s? " % (
+                        num_rolls - i + 1))
+            result += ((self.dice_sides ** (i - 1)) * (int(rolled) - 1))
+        index = math.floor(result / max_result * len(sequence))
+        return sequence[index]

--- a/tests/test_random_sources.py
+++ b/tests/test_random_sources.py
@@ -334,8 +334,8 @@ class TestRealDiceRandomSource(object):
         src = RealDiceRandomSource(argparse.Namespace(dice_sides=2))
         assert src.get_num_rolls(2) == 1
         assert src.get_num_rolls(2**12) == 12
-        assert src.get_num_rolls(3) == 1
-        assert src.get_num_rolls(2**12 + 1) == 12
+        assert src.get_num_rolls(3) == 2
+        assert src.get_num_rolls(2**12 + 1) == 13
 
     def test_main_with_realdice_source(
             self, argv_handler, capsys, fake_input):


### PR DESCRIPTION
## Number of rolls

There is a warning on entropy because the number of rolls required was underestimated.

> diceware -r realdice --dice-sides 20 -n 1 -d ' '
Warning: entropy is reduced! Using only first 400 of 7776 words/items of your wordlist.
Please roll 2 dice (or a single dice 2 times).

The number of rolls must be a math.ceil, not a int/math.floor. For a 20-sided dice, there must be 3 rolls for 7776 items not 2.

Same issue in the unit tests, with a two-sided dice, 2 rolls are required for a sequence of 3 elements not 1.

This change breaks tests about the hint like test_choice_prints_hint_on_repeated_rolls. They haven't been removed in this change although they are no longer relevant.

## Distribution of choices

The fix for issue ulif/diceware#35 consists in asking the user to re-enter rolls when the value generated exceeds the length of the sequence. This is not necessary. The result must be mapped to the actual sequence length instead.

This change breaks some tests like test_choice_distributes_equally_on_long_seq. It is not clear what these tests are about.
