### PR TITLE
Handle FileNotFoundError with proper error message

### DIFF
--- a/diceware/__init__.py
+++ b/diceware/__init__.py
@@ -18,6 +18,8 @@
 import argparse
 import pkg_resources
 import sys
+import logging
+from errno import ENOENT
 from random import SystemRandom
 from diceware.config import get_config_dict
 from diceware.logger import configure
@@ -208,4 +210,12 @@ def main(args=None):
     if options.version:
         print_version()
         raise SystemExit(0)
-    print(get_passphrase(options))
+    try:
+        print(get_passphrase(options))
+    except (OSError, IOError) as infile_error:
+        if getattr(infile_error, 'errno', 0) == ENOENT:
+            logging.getLogger('ulif.diceware').error(
+                "The file '%s' does not exist." % infile_error.filename)
+            raise SystemExit(1)
+        else:
+            raise

--- a/diceware/wordlist.py
+++ b/diceware/wordlist.py
@@ -111,6 +111,7 @@ class WordList(object):
     """
     def __init__(self, path):
         self.path = path
+        self.fd = None
         if self.path == "-":
             self.fd = tempfile.SpooledTemporaryFile(
                     max_size=MAX_IN_MEM_SIZE, mode="w+")
@@ -121,7 +122,7 @@ class WordList(object):
         self.signed = self.is_signed()
 
     def __del__(self):
-        if self.path != "-":
+        if self.path != "-" and self.fd is not None:
             self.fd.close()
 
     def __iter__(self):


### PR DESCRIPTION
As discussed in #43, now it shows proper error message if given wordlist file doesn't exist.
fixes #43 