### PR TITLE
Fix to formatting of list in Wordlists section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -423,7 +423,7 @@ Links
 
 Wordlists:
 
-_ `Diceware standard list`_ by Arnold G. Reinhold.
+- `Diceware standard list`_ by Arnold G. Reinhold.
 - `Diceware8k list`_ by Arnold G. Reinhold.
 - `Diceware SecureDrop list`_ by `@heartsucker`_.
 - `EFF large list`_ provided by EFF_.


### PR DESCRIPTION

I saw that the "Wordlists" list looked like this:

![image](https://user-images.githubusercontent.com/374060/38763790-28892ff2-3f71-11e8-93ab-26eac4006a89.png)

...so I fixed it. :-)

BTW, I'm thrilled that there's a CLI version of Diceware that works really well.  I actually built a web-based on awhile ago which is other side of that proverbial coin.  Feel free to check it out: https://github.com/dmuth/diceware

-- Doug

