### PR TITLE
Add option -m/--max

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,8 @@ Once installed, use ``--help`` to list all available options::
     --no-caps             Turn off capitalization.
     -s NUM, --specials NUM
                           Insert NUM special chars into generated word.
+    -m NUM, --max NUM
+                          Truncate to NUM length.
     -d DELIMITER, --delimiter DELIMITER
                           Separate words by DELIMITER. Empty string by default.
     -r SOURCE, --randomsource SOURCE

--- a/diceware/__init__.py
+++ b/diceware/__init__.py
@@ -105,6 +105,9 @@ def handle_options(args):
         '-s', '--specials', default=0, type=int, metavar='NUM',
         help="Insert NUM special chars into generated word.")
     parser.add_argument(
+        '-m', '--max', default=0, type=int, metavar='NUM',
+        help="Truncate to NUM length.")        
+    parser.add_argument(
         '-d', '--delimiter', default='',
         help="Separate words by DELIMITER. Empty string by default.")
     parser.add_argument(
@@ -193,6 +196,8 @@ def get_passphrase(options=None):
     result = options.delimiter.join(words)
     for _ in range(options.specials):
         result = insert_special_char(result, rnd=rnd)
+    if options.max > 0:
+        result = result[:options.max]
     return result
 
 

--- a/diceware/config.py
+++ b/diceware/config.py
@@ -30,6 +30,7 @@ OPTIONS_DEFAULTS = dict(
     num=6,
     caps=True,
     specials=0,
+    max=0,
     delimiter="",
     randomsource="system",
     verbose=0,

--- a/tests/sample_dot_diceware.ini
+++ b/tests/sample_dot_diceware.ini
@@ -3,6 +3,7 @@ num = 6
 caps = on
 specials = 0
 delimiter = ""
+max = 0
 randomsource = "system"
 verbose = 0
 wordlist = "en_securedrop"


### PR DESCRIPTION
#65 

```
    -m NUM, --max NUM
                          Truncate to NUM length.
```

Saw this request and thought it would be useful as long as some websites limit the length of passwords. 