### PR TITLE
Add `--inline` flag for realdice random source

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,10 +153,11 @@ lib but you can also bring your own dice to create randomness::
 
   $ diceware -r realdice --dice-sides 6
   Please roll 5 dice (or a single dice 5 times).
-  What number shows dice number 1? 2
-  What number shows dice number 2? 3
+  Enter your 5 dice results, separated by spaces: 6 4 2 3 1
+  Please roll 5 dice (or a single dice 5 times).
+  Enter your 5 dice results, separated by spaces: 5 4 3 6 2
   ...
-  DogmaAnyShrikeSageSableHoar
+  UnleveledSimilarlyBackboardMurkyOasisReplay
 
 Normally dice have six sides. And this is also the default in
 `diceware` if you do not use ``--dice-sides``. But if you do, you can

--- a/diceware/__init__.py
+++ b/diceware/__init__.py
@@ -127,10 +127,6 @@ def handle_options(args):
             '--dice-sides', default=6, type=int, metavar="N",
             help='Number of sides of dice. Default: 6'
         )
-    realdice_group.add_argument(
-            '--inline', default=False, action='store_const', const=True,
-            help='Accept a space-separated list of values rather than one at a time'
-    )
     parser.add_argument(
         'infile', nargs='?', metavar='INFILE', default=None,
         help="Input wordlist. `-' will read from stdin.",
@@ -147,10 +143,6 @@ def handle_options(args):
             parser = plugin.update_argparser(parser)
     parser.set_defaults(**defaults)
     args = parser.parse_args(args)
-    if args.randomsource != 'realdice' and args.inline:
-        parser.error(
-            '--inline option can only be used with real dice (-r realdice)'
-        )
     return args
 
 

--- a/diceware/__init__.py
+++ b/diceware/__init__.py
@@ -147,6 +147,10 @@ def handle_options(args):
             parser = plugin.update_argparser(parser)
     parser.set_defaults(**defaults)
     args = parser.parse_args(args)
+    if args.randomsource != 'realdice' and args.inline:
+        parser.error(
+            '--inline option can only be used with real dice (-r realdice)'
+        )
     return args
 
 

--- a/diceware/__init__.py
+++ b/diceware/__init__.py
@@ -127,6 +127,10 @@ def handle_options(args):
             '--dice-sides', default=6, type=int, metavar="N",
             help='Number of sides of dice. Default: 6'
         )
+    realdice_group.add_argument(
+            '--inline', default=False, action='store_const', const=True,
+            help='Accept a space-separated list of values rather than one at a time'
+    )
     parser.add_argument(
         'infile', nargs='?', metavar='INFILE', default=None,
         help="Input wordlist. `-' will read from stdin.",

--- a/diceware/random_sources.py
+++ b/diceware/random_sources.py
@@ -130,10 +130,8 @@ class RealDiceRandomSource(object):
     def __init__(self, options):
         self.options = options
         self.dice_sides = 6
-        self.is_inline = False
         if options is not None:
             self.dice_sides = getattr(options, 'dice_sides', 6)
-            self.is_inline = getattr(options, 'inline', False)
 
     def pre_check(self, num_rolls, sequence):
         """Checks performed before picking an item of a sequence.
@@ -175,12 +173,8 @@ class RealDiceRandomSource(object):
         repeat = True
         while repeat:
             result = 0
-            if self.is_inline:
-                roll_gen = self.__roll_gen_inline
-            else:
-                roll_gen = self.__roll_gen_normal
 
-            for i, rolled in roll_gen(num_rolls):
+            for i, rolled in self.__roll_gen_inline(num_rolls):
                 result += ((self.dice_sides ** (i - 1)) * (int(rolled) - 1))
             if result < len(sequence):
                 repeat = False
@@ -188,18 +182,6 @@ class RealDiceRandomSource(object):
                 print("Value out of range. Please roll dice again.")
         return sequence[result]
 
-    def __roll_gen_normal(self, num_rolls):
-        """Ask the user for each dice result one at a time
-        """
-        for i in range(num_rolls, 0, -1):
-            rolled = None
-            while rolled not in [
-                    str(x) for x in range(1, self.dice_sides + 1)]:
-                rolled = input_func(
-                    "What number shows dice number %s? " % (
-                        num_rolls - i + 1))
-            yield i, rolled
-    
     def __roll_gen_inline(self, num_rolls):
         """Ask the user for all dice results at once
         """

--- a/diceware/random_sources.py
+++ b/diceware/random_sources.py
@@ -174,7 +174,7 @@ class RealDiceRandomSource(object):
         while repeat:
             result = 0
 
-            for i, rolled in self.__roll_gen_inline(num_rolls):
+            for i, rolled in self.__get_rolls(num_rolls):
                 result += ((self.dice_sides ** (i - 1)) * (int(rolled) - 1))
             if result < len(sequence):
                 repeat = False
@@ -182,7 +182,7 @@ class RealDiceRandomSource(object):
                 print("Value out of range. Please roll dice again.")
         return sequence[result]
 
-    def __roll_gen_inline(self, num_rolls):
+    def __get_rolls(self, num_rolls):
         """Ask the user for all dice results at once
         """
         rolls = []
@@ -191,5 +191,4 @@ class RealDiceRandomSource(object):
             rolls = input_func(
                 "Enter your %d dice results, separated by spaces: "
                     % num_rolls).split()
-        for i, roll in enumerate(rolls):
-            yield num_rolls - i, roll
+        return [(num_rolls - i, roll) for i, roll in enumerate(rolls)]

--- a/tests/test_random_sources.py
+++ b/tests/test_random_sources.py
@@ -337,36 +337,6 @@ class TestRealDiceRandomSource(object):
         assert src.get_num_rolls(3) == 1
         assert src.get_num_rolls(2**12 + 1) == 12
 
-    def test_non_numbers_as_input_are_rejected_inline(self, fake_input):
-        # Users might input non-numbers. We ask again then.
-        fake_input(["no number", "", "1 2"])
-        src = RealDiceRandomSource(argparse.Namespace(inline=True))
-        assert src.choice([i for i in range(1, 37)]) == 2
-
-    def test_choice_input_lower_value_borders_inline(self, fake_input):
-        # choice() does not accept "0" but it accepts "1"
-        fake_input(["0 1", "1 0", "1 1"])
-        src = RealDiceRandomSource(argparse.Namespace(inline=True))
-        sequence = [i for i in range(1, 37)]
-        assert src.choice(sequence) == 1
-
-    def test_choice_num_of_dice_for_seq_len36_inline(self, fake_input):
-        # choice() requires two dice for a sequence len of 6**2
-        fake_input(["1 2"])
-        src = RealDiceRandomSource(argparse.Namespace(inline=True))
-        sequence = list(range(6 ** 2))
-        expected_index = 6 * (1 - 1) + (2 - 1)     # = 6 x roll_1 + roll_2 - 1
-        assert src.choice(sequence) == sequence[expected_index]
-
-    def test_choice_num_of_dice_for_seq_len216_inline(self, fake_input):
-        # choice() requires three dice for a sequence len of 6**3
-        fake_input(["1 2 3"])
-        src = RealDiceRandomSource(argparse.Namespace(inline=True))
-        sequence = list(range(6 ** 3))        # 216
-        # = 6^2 * (roll_1 - 1) + 6^1 * (roll_2 - 1) + (roll_3 - 1)
-        expected_index = 0 + 6 + 3 - 1
-        assert src.choice(sequence) == sequence[expected_index]
-
     def test_main_with_realdice_source(
             self, argv_handler, capsys, fake_input):
         # we can run main with `realdice` source of randomness

--- a/tests/test_random_sources.py
+++ b/tests/test_random_sources.py
@@ -337,6 +337,36 @@ class TestRealDiceRandomSource(object):
         assert src.get_num_rolls(3) == 1
         assert src.get_num_rolls(2**12 + 1) == 12
 
+    def test_non_numbers_as_input_are_rejected_inline(self, fake_input):
+        # Users might input non-numbers. We ask again then.
+        fake_input(["no number", "", "1 2"])
+        src = RealDiceRandomSource(argparse.Namespace(inline=True))
+        assert src.choice([i for i in range(1, 37)]) == 2
+
+    def test_choice_input_lower_value_borders_inline(self, fake_input):
+        # choice() does not accept "0" but it accepts "1"
+        fake_input(["0 1", "1 0", "1 1"])
+        src = RealDiceRandomSource(argparse.Namespace(inline=True))
+        sequence = [i for i in range(1, 37)]
+        assert src.choice(sequence) == 1
+
+    def test_choice_num_of_dice_for_seq_len36_inline(self, fake_input):
+        # choice() requires two dice for a sequence len of 6**2
+        fake_input(["1 2"])
+        src = RealDiceRandomSource(argparse.Namespace(inline=True))
+        sequence = list(range(6 ** 2))
+        expected_index = 6 * (1 - 1) + (2 - 1)     # = 6 x roll_1 + roll_2 - 1
+        assert src.choice(sequence) == sequence[expected_index]
+
+    def test_choice_num_of_dice_for_seq_len216_inline(self, fake_input):
+        # choice() requires three dice for a sequence len of 6**3
+        fake_input(["1 2 3"])
+        src = RealDiceRandomSource(argparse.Namespace(inline=True))
+        sequence = list(range(6 ** 3))        # 216
+        # = 6^2 * (roll_1 - 1) + 6^1 * (roll_2 - 1) + (roll_3 - 1)
+        expected_index = 0 + 6 + 3 - 1
+        assert src.choice(sequence) == sequence[expected_index]
+
     def test_main_with_realdice_source(
             self, argv_handler, capsys, fake_input):
         # we can run main with `realdice` source of randomness

--- a/tests/test_random_sources.py
+++ b/tests/test_random_sources.py
@@ -144,7 +144,7 @@ class TestRealDiceRandomSource(object):
 
     def test_choice_num_of_dice_for_seq_len36(self, fake_input):
         # choice() requires two dice for a sequence len of 6**2
-        fake_input(["1", "2"])
+        fake_input(["1 2"])
         src = RealDiceRandomSource(None)
         sequence = list(range(6 ** 2))
         expected_index = 6 * (1 - 1) + (2 - 1)     # = 6 x roll_1 + roll_2 - 1
@@ -152,7 +152,7 @@ class TestRealDiceRandomSource(object):
 
     def test_choice_num_of_dice_for_seq_len216(self, fake_input):
         # choice() requires three dice for a sequence len of 6**3
-        fake_input(["1", "2", "3"])
+        fake_input(["1 2 3"])
         src = RealDiceRandomSource(None)
         sequence = list(range(6 ** 3))        # 216
         # = 6^2 * (roll_1 - 1) + 6^1 * (roll_2 - 1) + (roll_3 - 1)
@@ -174,7 +174,7 @@ class TestRealDiceRandomSource(object):
 
     def test_no_hint_if_entropy_is_not_decreased(self, fake_input, capsys):
         # we do not issue the entropy warning if not neccessary
-        fake_input(["1"] * 6)
+        fake_input(["1", "1 1", "1 1 1"])
         src = RealDiceRandomSource(None)
         picked1 = src.choice([1, 2, 3, 4, 5, 6])
         picked2 = src.choice(range(1, 6 ** 2 + 1))
@@ -318,7 +318,7 @@ class TestRealDiceRandomSource(object):
 
     def test_choice_respects_dice_sides(self, capsys, fake_input):
         # we use the number of dice sides given by options dict.
-        fake_input(["1", "2"])
+        fake_input(["1 2"])
         # A Namespace, not a dict, is passed to the constructor.
         options = argparse.Namespace(dice_sides=2)  # a coin
         src = RealDiceRandomSource(options)


### PR DESCRIPTION
I took a crack at implementing #58 
When using the 'realdice' method, you can now pass the additional `--inline` flag, causing it to expect a list of whitespace-separated numbers all in one line, rather than one at a time like normal:

```
❯ diceware -r realdice --inline -n 3 -s 1
Please roll 5 dice (or a single dice 5 times).
Enter your 5 dice results, separated by spaces: 1 1 1 1 1
Please roll 5 dice (or a single dice 5 times).
Enter your 5 dice results, separated by spaces: 2 2 2 2 2
Please roll 5 dice (or a single dice 5 times).
Enter your 5 dice results, separated by spaces: 3 3 3 3 3
Please roll 2 dice (or a single dice 2 times).
Enter your 2 dice results, separated by spaces: 4 4
Warning: entropy is reduced! Using only first 6 of 20 words/items of your wordlist.
Please roll 1 dice (or a single dice 1 times).
Enter your 1 dice results, separated by spaces: 5
Abac'sDatingHandgrip
```

Unlike #25, this takes rolls from standard input just like the existing methods, so hopefully doesn't have any extra security implications.
I'm not very familiar with pytest, but I made some simple modified versions of the existing tests, updated to use inline numbers. They're nothing particularly exciting, but enough to make sure that the inline mode works the same as the standard realdice mode