### PR TITLE
Flexible separators, informative errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ develop-eggs/
 dist/
 downloads/
 eggs/
+.eggs/
 lib/
 lib64/
 parts/

--- a/diceware/random_sources.py
+++ b/diceware/random_sources.py
@@ -214,3 +214,4 @@ class RealDiceRandomSource(object):
                 # i.e. The entry is valid
                 pass
         return [(num_rolls - i, roll) for i, roll in enumerate(rolls)]
+        

--- a/diceware/random_sources.py
+++ b/diceware/random_sources.py
@@ -74,6 +74,7 @@ generating a passphrase.
 """
 import math
 import sys
+import re
 from random import SystemRandom
 
 
@@ -149,8 +150,8 @@ class RealDiceRandomSource(object):
                 )
             )
         print(
-            "Please roll %s dice (or a single dice %s times)." % (
-                num_rolls, num_rolls))
+            "Please roll %s %s-sided dice (or a single %s-sided die %s times)." % (
+                num_rolls, self.dice_sides, self.dice_sides, num_rolls))
         return
 
     def get_num_rolls(self, seq_len):
@@ -188,7 +189,23 @@ class RealDiceRandomSource(object):
         rolls = []
         valid_rolls = [str(x) for x in range(1, self.dice_sides + 1)]
         while len(rolls) != num_rolls or not set(rolls).issubset(valid_rolls):
-            rolls = input_func(
-                "Enter your %d dice results, separated by spaces: "
-                    % num_rolls).split()
+            entry = input_func(
+                "Enter your %d dice results, separated by non-digit characters: "
+                    % num_rolls)
+            rolls = re.split('\D+', entry)
+            if len (rolls) > num_rolls:
+                del rolls[num_rolls:]
+                print ("  Warning:  Input had too many entries, only using the first %s." 
+                    % num_rolls)
+            elif len (rolls) < num_rolls:
+                print ("  Warning:  Input had too few entries.  Please retry...")
+            else:
+                # i.e. the entry is the right length
+                pass
+            if not set(rolls).issubset(valid_rolls):
+                print ("  Warning:  \"%s\" is not a valid entry.  Please retry..." 
+                    % entry)
+            else:
+                # i.e. The entry is valid
+                pass
         return [(num_rolls - i, roll) for i, roll in enumerate(rolls)]

--- a/diceware/random_sources.py
+++ b/diceware/random_sources.py
@@ -144,13 +144,14 @@ class RealDiceRandomSource(object):
             raise(ValueError)
         if (self.dice_sides ** num_rolls) < len(sequence):
             print(
-                "Warning: entropy is reduced! Using only first %s of %s "
+                "  Warning: entropy is reduced! Using only first %s of %s "
                 "words/items of your wordlist." % (
                     self.dice_sides ** num_rolls, len(sequence)
                 )
             )
         print(
-            "Please roll %s %s-sided dice (or a single %s-sided die %s times)." % (
+            "Please roll %s %s-sided dice (or a single %s-sided die "
+            "%s times)." % (
                 num_rolls, self.dice_sides, self.dice_sides, num_rolls))
         return
 
@@ -190,21 +191,25 @@ class RealDiceRandomSource(object):
         valid_rolls = [str(x) for x in range(1, self.dice_sides + 1)]
         while len(rolls) != num_rolls or not set(rolls).issubset(valid_rolls):
             entry = input_func(
-                "Enter your %d dice results, separated by non-digit characters: "
+                "Enter your %d dice results, "
+                "separated by non-digit characters: "
                     % num_rolls)
             rolls = re.split('\D+', entry)
+            # remove trailing empty entries
+            rolls = list(filter(None,rolls))
             if len (rolls) > num_rolls:
                 del rolls[num_rolls:]
-                print ("  Warning:  Input had too many entries, only using the first %s." 
+                print ("  Warning:  Input had too many entries, only using "
+                    "the first %s."     
                     % num_rolls)
-            elif len (rolls) < num_rolls:
-                print ("  Warning:  Input had too few entries.  Please retry...")
-            else:
-                # i.e. the entry is the right length
-                pass
-            if not set(rolls).issubset(valid_rolls):
-                print ("  Warning:  \"%s\" is not a valid entry.  Please retry..." 
+            if len (rolls) < num_rolls:
+                print ("  Warning:  Input had too few entries.  "
+                    "Please retry...")
+            elif not set(rolls).issubset(valid_rolls):
+                print ("  Warning:  \"%s\" is not a valid entry.  "
+                    "Please retry..." 
                     % entry)
+                print ("    Values must be between 1 and %s" % self.dice_sides)
             else:
                 # i.e. The entry is valid
                 pass

--- a/diceware/random_sources.py
+++ b/diceware/random_sources.py
@@ -195,7 +195,7 @@ class RealDiceRandomSource(object):
                 "separated by non-digit characters: "
                     % num_rolls)
             rolls = re.split('\D+', entry)
-            # remove trailing empty entries
+            # remove null/empty entries
             rolls = list(filter(None,rolls))
             if len (rolls) > num_rolls:
                 del rolls[num_rolls:]


### PR DESCRIPTION
This does a few things:

* Excludes `.eggs/` from the git repo to help developers
* Adds regular-expression-based splitting to allow any non-digit separator (possibly except backslashes?) 
* If the entry has nulls at the beginning or end, it discards those nulls.  
* If the entry is too long, it truncates to the first N inputs (and gives a warning)
* If the entry is too short, it says so and prompts for reentry
* If the entry is the right length, but invalid, it gives a warning to retry with the range of accepted values
* Improves formatting of warnings and fixes a grammar issue.  

This should address issue #74.  

I did not introduce new tests.  I suggest that the following strings could be test cases:

Accept:
```
1 2 3 4 5
1,2,3,4,5
,1,2,3,4,5,
```
Accept with warning:
```
1,2,3,4,5,6,
```
Reject (too short):
```
,1,2,
1,2,3,4,
11,2
```
Reject (value out of range):
```
11,2,3,4,5
1,22,3,4,5
```