### PR TITLE
.eggs/ now ignored by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.eggs/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template


### PR DESCRIPTION
The dev instructions create a .eggs/ directory in the diceware directory and git lists it as an Untracked item.  