### PR TITLE
non-whitespace separators allowed in realdice input

### DIFF
--- a/diceware/random_sources.py
+++ b/diceware/random_sources.py
@@ -74,6 +74,7 @@ generating a passphrase.
 """
 import math
 import sys
+import re
 from random import SystemRandom
 
 
@@ -188,7 +189,9 @@ class RealDiceRandomSource(object):
         rolls = []
         valid_rolls = [str(x) for x in range(1, self.dice_sides + 1)]
         while len(rolls) != num_rolls or not set(rolls).issubset(valid_rolls):
-            rolls = input_func(
-                "Enter your %d dice results, separated by spaces: "
-                    % num_rolls).split()
+            rolls = re.split(r'\D+', input_func(
+                "Enter your %d dice results, separated by non-digits: "
+                    % num_rolls))
+            # remove leading/trailing Nones
+            rolls = list(filter(None, rolls))
         return [(num_rolls - i, roll) for i, roll in enumerate(rolls)]

--- a/tests/test_random_sources.py
+++ b/tests/test_random_sources.py
@@ -158,6 +158,42 @@ class TestRealDiceRandomSource(object):
         # = 6^2 * (roll_1 - 1) + 6^1 * (roll_2 - 1) + (roll_3 - 1)
         expected_index = 0 + 6 + 3 - 1
         assert src.choice(sequence) == sequence[expected_index]
+    
+    def test_choice_copes_with_non_digit_separators(self, fake_input):
+        # choice() requires three dice for a sequence len of 6**3
+        fake_input(["1,2,3"])
+        src = RealDiceRandomSource(None)
+        sequence = list(range(6 ** 3))        # 216
+        # = 6^2 * (roll_1 - 1) + 6^1 * (roll_2 - 1) + (roll_3 - 1)
+        expected_index = 0 + 6 + 3 - 1
+        assert src.choice(sequence) == sequence[expected_index]
+
+    def test_choice_copes_with_leading_separator(self, fake_input):
+        # choice() requires three dice for a sequence len of 6**3
+        fake_input([",1,2,3"])
+        src = RealDiceRandomSource(None)
+        sequence = list(range(6 ** 3))        # 216
+        # = 6^2 * (roll_1 - 1) + 6^1 * (roll_2 - 1) + (roll_3 - 1)
+        expected_index = 0 + 6 + 3 - 1
+        assert src.choice(sequence) == sequence[expected_index]
+
+    def test_choice_copes_with_trailing_separator(self, fake_input):
+        # choice() requires three dice for a sequence len of 6**3
+        fake_input(["1,2,3,"])
+        src = RealDiceRandomSource(None)
+        sequence = list(range(6 ** 3))        # 216
+        # = 6^2 * (roll_1 - 1) + 6^1 * (roll_2 - 1) + (roll_3 - 1)
+        expected_index = 0 + 6 + 3 - 1
+        assert src.choice(sequence) == sequence[expected_index]
+
+    def test_choice_copes_with_multicharacter_separator(self, fake_input):
+        # choice() requires three dice for a sequence len of 6**3
+        fake_input(["1,,2  3"])
+        src = RealDiceRandomSource(None)
+        sequence = list(range(6 ** 3))        # 216
+        # = 6^2 * (roll_1 - 1) + 6^1 * (roll_2 - 1) + (roll_3 - 1)
+        expected_index = 0 + 6 + 3 - 1
+        assert src.choice(sequence) == sequence[expected_index]
 
     def test_hint_if_entropy_is_decreased(self, fake_input, capsys):
         # if len of choice is not a multiple of 6, entropy is decreased


### PR DESCRIPTION
This pull uses a regular expression to separate numbers by non-digit characters.  

Addresses issue #74 