### PR TITLE
Install manpage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,8 @@ packages = ["diceware", "diceware.wordlists" ]
 [tool.setuptools.package-data]
 "diceware.wordlists" = ["*.txt", "*.asc"]
 
+[tool.setuptools.data-files]
+"share/man/man1" = ["*.1"]
 
 [tool.setuptools.dynamic]
 version = {attr = "diceware.__version__"}


### PR DESCRIPTION
This installs the manpage at `{venv}/share/man/man1`, which is recognized by installers like [pipx](https://pipx.pypa.io/stable/how-pipx-works/#manual-pages) and [homebrew](https://github.com/Homebrew/brew/blob/1f55f0c01a1afe667e373e969bca234a9ddad290/Library/Homebrew/language/python.rb#L440-L443) (with [uv](https://github.com/astral-sh/uv/issues/4731) to hopefully follow soon)
